### PR TITLE
Changed the definition of leader.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -16,7 +16,7 @@ let $PATH='/usr/local/bin:' . $PATH
 let g:session_autoload = 'no'
 
 " Leader Mappings
-let mapleader = "\<Space>"
+map <Space> <leader>
 map <Leader>w :update<CR>
 map <Leader>q :qall<CR>
 "
@@ -42,8 +42,8 @@ set notimeout
 
 " highlight vertical column of cursor
 au WinLeave * set nocursorline nocursorcolumn
-au WinEnter * set cursorline 
-set cursorline 
+au WinEnter * set cursorline
+set cursorline
 
 "key to insert mode with paste using F2 key
 map <F2> :set paste<CR>i


### PR DESCRIPTION
I always found that:

```vim
let mapleader = "\<Space>
```

Led to some problems for me. using:

```vim
map <Space> <leader>
```

works better. In particular, when I am editing a file with the former mapping,
the space would not show as soon as I entered the space key, while the latter
does show the space right away.

Also removed some trailing whitespaces.