### PR TITLE
Addition to the removal of trailing whitespaces

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -240,7 +240,7 @@ function! s:RemoveTrailingWhitespaces()
   call cursor(l,c)
 endfunction
 
-au BufWritePre * :call <SID>MyFormattingSubs()
+au BufWritePre * :call <SID>RemoveTrailingWhitespaces()
 
 " cmd n, cmd p for fwd/backward in search
 map <C-n> :cn<CR>

--- a/vimrc
+++ b/vimrc
@@ -229,7 +229,18 @@ if filereadable($HOME . "/.vimrc.local")
 endif
 
 " Remove trailing whitespace on save for ruby files.
-au BufWritePre *.rb :%s/\s\+$//e
+function! s:RemoveTrailingWhitespaces()
+  "Save last cursor position
+  let l = line(".")
+  let c = col(".")
+
+  %s/\s\+$//ge
+
+  let @/=_s
+  call cursor(l,c)
+endfunction
+
+au BufWritePre * :call <SID>MyFormattingSubs()
 
 " cmd n, cmd p for fwd/backward in search
 map <C-n> :cn<CR>


### PR DESCRIPTION
By putting the substitution that you had before into this function, when the
function is called it will also save your current cursor position before the
substitution is made. This way, after a substitution is made on a save your
cursor will not be at the bottom of the file where the last substitution was
made.

I also have:

```vim
au BufWritePre * :call...
```

instead of:

```vim
au BufWritePre *.rb :call...
```

Because I like to remove trailing whitespace from all files I save with vim, not
just ruby files. But if you prefer to only have that take effect in ruby files
then that line can be changed to reflect that.