### PR TITLE
changes in README.md to ease my frustration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![dotfiles](https://raw.githubusercontent.com/mscoutermarsh/dotfiles/master/autobot.jpg)
 
-dotfiles
+dotfiles for MAC
 ===================
 ![screenshot](https://github.com/mscoutermarsh/dotfiles/blob/master/screenshot.png)
 (Here's what my setup looks like. Vim/Tmux)
@@ -12,6 +12,7 @@ dotfiles
 If you're brand new to Vim, I recommend using [ThoughtBot's dotfiles](https://github.com/thoughtbot/dotfiles). They are better maintained than mine :).  
 
 ## Installation
+**Warning:** Installation process described below works seamlessly for MAC only. In adition, when you run vim for the 1st time after installation, execute `:PlugInstall` to install all plugins requested.
 
 If you have trouble during installation, please open an issue or pull request. :star:
 
@@ -21,7 +22,6 @@ git clone https://github.com/mscoutermarsh/dotfiles ~/.dotfiles
 cd ~/.dotfiles
 ./install
 ```
-
 ### Recommended
 
 **iterm2**
@@ -40,3 +40,4 @@ $ brew install reattach-to-user-namespace
 
 #### Contributing
 Did you have trouble installing this? Could I make the documentation better? Let me know [@mscccc](http://twitter.com/mscccc). Or please fork & create a pull request with your suggestions.
+


### PR DESCRIPTION
I am too green to make changes in the install process of _dotfiles_.  My original frustration was that after installing _dotfiles_, I had error displayed while starting vim:
`
Error detected while processing /home/tad/.vimrc:
line   65:
E185: Cannot find color scheme 'solarized'
Press ENTER or type command to continue
`
and colours where not displayed 'solarized'.  After long investigation (learning vim and git) I figured out the culprit:  plugins must be installed first.  

There was another problem with another plugin which required MAC (zerowidth/vim-copy-as-rtf?), but it is beyond the scope of this pull request.

Long story short: it takes longer then a week to learn vim.